### PR TITLE
Support for Django 4

### DIFF
--- a/tests/tsvector_test_app/settings.py
+++ b/tests/tsvector_test_app/settings.py
@@ -12,3 +12,5 @@ DATABASES = {
     }
 }
 SECRET_KEY = 'test-key'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist = py{35,36}-django{1,2}
+envlist =
+    clear
+    py{34,35,36,37}-django1
+    py{35,36,37,38,39}-django2
+    py{36,37,38,39,310}-django3
+    py{38,39,310,311}-django4
+    report
+skip_missing_interpreters = true
 
 [travis:env]
 DJANGO =
@@ -12,11 +19,20 @@ setenv =
   DJANGO_SETTINGS_MODULE=tsvector_test_app.settings
 
 deps =
-  django1: django~=1.11.0
-  django2: git+https://github.com/django/django.git
+  django1: django==1.*
+  django2: django==2.*
+  django3: django==3.*
+  django4: django==4.1.*
   psycopg2
   coverage
 
 commands =
-  coverage run -p --source={envsitepackagesdir}/tsvector_field {envbindir}/django-admin.py test tsvector_test_app
-  coverage combine
+  coverage run -p --source={envsitepackagesdir}/tsvector_field {envbindir}/django-admin test tsvector_test_app
+
+[testenv:clear]
+commands = -coverage erase
+
+[testenv:report]
+commands =
+    -coverage combine
+    -coverage report

--- a/tsvector_field/fields.py
+++ b/tsvector_field/fields.py
@@ -1,6 +1,9 @@
 from django.core import checks
 from django.db.models import CharField, TextField
-from django.utils.encoding import force_text
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str as force_text
 from django.utils.itercompat import is_iterable
 from django.contrib.postgres.search import SearchVectorField as OriginalSearchVectorField
 


### PR DESCRIPTION
In `fields.py`, import `force_str` instead of `force_text` if `force_text` cannot be imported.

Django 4.0 removed `django.utils.encoding.force_text()` ([features removed in Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0)).

Closes #8 